### PR TITLE
Add 3D overlay script with move highlighting

### DIFF
--- a/board_3d_overlay.py
+++ b/board_3d_overlay.py
@@ -201,6 +201,70 @@ def _square_pose(row, col, thickness=0.001):
     return T
 
 
+def generate_board_overlay_with_move(board, models, pose, camera_matrix,
+                                     width, height, move=None):
+    """Return a transparent RGBA render of the board with ``move`` highlighted."""
+    scene = pyrender.Scene(bg_color=[0, 0, 0, 0], ambient_light=[0.3, 0.3, 0.3])
+
+    camera = pyrender.IntrinsicsCamera(
+        fx=camera_matrix[0, 0],
+        fy=camera_matrix[1, 1],
+        cx=camera_matrix[0, 2],
+        cy=camera_matrix[1, 2],
+        znear=0.01,
+        zfar=10.0,
+    )
+    scene.add(camera, pose=_camera_pose(pose))
+
+    light_pose = np.eye(4)
+    light_pose[:3, 3] = [-40, 60, 80]
+    light = pyrender.DirectionalLight(color=np.ones(3), intensity=4.0)
+    scene.add(light, pose=light_pose)
+
+    for square, piece in board.piece_map().items():
+        row, col = square_to_board_coords(square)
+        key = ("b" if piece.color == False else "w") + piece.symbol().upper()
+        mesh = models.get(key)
+        if mesh is None:
+            continue
+
+        WHITE_COLOR = [0.0, 0.0, 1.0, PIECE_ALPHA]
+        BLACK_COLOR = [1.0, 0.0, 0.0, PIECE_ALPHA]
+        color = WHITE_COLOR if piece.color == False else BLACK_COLOR
+
+        material = pyrender.MetallicRoughnessMaterial(
+            baseColorFactor=color, metallicFactor=0.0, roughnessFactor=0.5
+        )
+        scene.add(
+            pyrender.Mesh.from_trimesh(mesh, material=material, smooth=False),
+            pose=compute_piece_pose(row, col, key),
+        )
+
+    if move is not None:
+        from_row, from_col = square_to_board_coords(move.from_square)
+        to_row, to_col = square_to_board_coords(move.to_square)
+        box = trimesh.creation.box(extents=[square_size_m, square_size_m, 0.001])
+
+        yellow = pyrender.MetallicRoughnessMaterial(
+            baseColorFactor=[1.0, 1.0, 0.0, 0.6], metallicFactor=0.0,
+            roughnessFactor=0.5
+        )
+        green = pyrender.MetallicRoughnessMaterial(
+            baseColorFactor=[0.0, 1.0, 0.0, 0.6], metallicFactor=0.0,
+            roughnessFactor=0.5
+        )
+
+        scene.add(pyrender.Mesh.from_trimesh(box, material=yellow, smooth=False),
+                  pose=_square_pose(from_row, from_col, 0.001))
+        scene.add(pyrender.Mesh.from_trimesh(box, material=green, smooth=False),
+                  pose=_square_pose(to_row, to_col, 0.001))
+
+    renderer = pyrender.OffscreenRenderer(width, height)
+    color, _ = renderer.render(scene, flags=pyrender.RenderFlags.RGBA)
+    renderer.delete()
+    return color
+
+
 def render_board_state_with_move(frame, board, models, pose, camera_matrix, move=None):
     """Render the board with pieces and optionally highlight ``move``."""
     scene = pyrender.Scene(bg_color=[0, 0, 0, 0], ambient_light=[0.3, 0.3, 0.3])

--- a/board_3d_overlay.py
+++ b/board_3d_overlay.py
@@ -189,3 +189,78 @@ def composite_overlay(frame, overlay_rgba):
     overlay = overlay_rgba[:, :, :3]
     alpha = overlay_rgba[:, :, 3:] / 255.0
     return (overlay * alpha + frame * (1 - alpha)).astype(np.uint8)
+
+
+
+def _square_pose(row, col, thickness=0.001):
+    """Return a pose that places a thin box on the board square."""
+    T = np.eye(4, dtype=np.float32)
+    T[0, 3] = (col + 0.5) * square_size_m
+    T[1, 3] = (row + 0.5) * square_size_m
+    T[2, 3] = thickness / 2
+    return T
+
+
+def render_board_state_with_move(frame, board, models, pose, camera_matrix, move=None):
+    """Render the board with pieces and optionally highlight ``move``."""
+    scene = pyrender.Scene(bg_color=[0, 0, 0, 0], ambient_light=[0.3, 0.3, 0.3])
+
+    camera = pyrender.IntrinsicsCamera(
+        fx=camera_matrix[0, 0],
+        fy=camera_matrix[1, 1],
+        cx=camera_matrix[0, 2],
+        cy=camera_matrix[1, 2],
+        znear=0.01,
+        zfar=10.0,
+    )
+    scene.add(camera, pose=_camera_pose(pose))
+
+    light_pose = np.eye(4)
+    light_pose[:3, 3] = [-40, 60, 80]
+    light = pyrender.DirectionalLight(color=np.ones(3), intensity=4.0)
+    scene.add(light, pose=light_pose)
+
+    for square, piece in board.piece_map().items():
+        row, col = square_to_board_coords(square)
+        key = ("b" if piece.color == False else "w") + piece.symbol().upper()
+        mesh = models.get(key)
+        if mesh is None:
+            continue
+
+        WHITE_COLOR = [0.0, 0.0, 1.0, PIECE_ALPHA]
+        BLACK_COLOR = [1.0, 0.0, 0.0, PIECE_ALPHA]
+        color = WHITE_COLOR if piece.color == False else BLACK_COLOR
+
+        material = pyrender.MetallicRoughnessMaterial(
+            baseColorFactor=color, metallicFactor=0.0, roughnessFactor=0.5
+        )
+        scene.add(
+            pyrender.Mesh.from_trimesh(mesh, material=material, smooth=False),
+            pose=compute_piece_pose(row, col, key),
+        )
+
+    if move is not None:
+        from_row, from_col = square_to_board_coords(move.from_square)
+        to_row, to_col = square_to_board_coords(move.to_square)
+        box = trimesh.creation.box(extents=[square_size_m, square_size_m, 0.001])
+
+        yellow = pyrender.MetallicRoughnessMaterial(
+            baseColorFactor=[1.0, 1.0, 0.0, 0.6], metallicFactor=0.0, roughnessFactor=0.5
+        )
+        green = pyrender.MetallicRoughnessMaterial(
+            baseColorFactor=[0.0, 1.0, 0.0, 0.6], metallicFactor=0.0, roughnessFactor=0.5
+        )
+
+        scene.add(pyrender.Mesh.from_trimesh(box, material=yellow, smooth=False),
+                  pose=_square_pose(from_row, from_col, 0.001))
+        scene.add(pyrender.Mesh.from_trimesh(box, material=green, smooth=False),
+                  pose=_square_pose(to_row, to_col, 0.001))
+
+    renderer = pyrender.OffscreenRenderer(frame.shape[1], frame.shape[0])
+    color, _ = renderer.render(scene, flags=pyrender.RenderFlags.RGBA)
+    renderer.delete()
+
+    overlay = color[:, :, :3]
+    alpha = color[:, :, 3:] / 255.0
+    return (overlay * alpha + frame * (1 - alpha)).astype(np.uint8)
+

--- a/dual_rendered_move.py
+++ b/dual_rendered_move.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""
+LeRobot move visualiser using a 3‑D rendered overlay. Similar to
+``dual_highlight_move.py`` but the physical camera feeds are blended with a
+rendered board and highlighted move squares.
+"""
+
+import cv2
+import pyvirtualcam
+import chess_vision
+import time
+import numpy as np
+import subprocess
+import chess
+import chess.engine
+import chess.svg
+import cairosvg
+import argparse
+from pyvirtualcam import PixelFormat
+
+from board_3d_overlay import (
+    load_piece_models,
+    render_board_state_with_move,
+)
+
+# --------------------------
+# 0) 2-D Board Rendering (unchanged)
+# --------------------------
+
+def generate_board_image(board: chess.Board, last_move: chess.Move | None, size: int = 480) -> np.ndarray:
+    svg_data = chess.svg.board(board=board, lastmove=last_move, size=size, coordinates=True)
+    png_bytes = cairosvg.svg2png(bytestring=svg_data.encode("utf-8"), output_width=size, output_height=size)
+    png_array = np.frombuffer(png_bytes, dtype=np.uint8)
+    img_bgra = cv2.imdecode(png_array, cv2.IMREAD_UNCHANGED)
+    img_bgr = cv2.cvtColor(img_bgra, cv2.COLOR_BGRA2BGR)
+    canvas = np.zeros((480, 640, 3), dtype=np.uint8)
+    x0 = (640 - size) // 2
+    canvas[:, x0:x0 + size, :] = img_bgr
+    return canvas
+
+
+# --------------------------
+# 1) Virtual Cameras
+# --------------------------
+
+def setup_virtual_cameras():
+    print("Setting up 5 virtual cameras (4-8)…")
+    subprocess.run(['sudo', 'modprobe', '-r', 'v4l2loopback'], check=True)
+    time.sleep(1)
+    subprocess.run([
+        'sudo', 'modprobe', 'v4l2loopback',
+        'devices=5',
+        'video_nr=4,5,6,7,8',
+        ('card_label="SO100 Black","SO100 White","OBS Black","OBS White","SO100 Board"'),
+        'yuv420=1',
+        'exclusive_caps=0'
+    ], check=True)
+    time.sleep(1)
+    for dev in ('/dev/video4', '/dev/video5', '/dev/video6', '/dev/video7', '/dev/video8'):
+        subprocess.run(['sudo', 'chmod', '666', dev], check=True)
+    print("Virtual camera setup complete!")
+
+
+# --------------------------
+# 2) Stockfish helpers
+# --------------------------
+
+def setup_chess_engine():
+    board = chess.Board()
+    try:
+        engine = chess.engine.SimpleEngine.popen_uci("/usr/games/stockfish")
+        print("Chess engine initialized successfully!")
+        return board, engine
+    except Exception as e:
+        print(f"Error initializing chess engine: {e}")
+        return None, None
+
+
+def get_next_move(board, engine):
+    return engine.play(board, chess.engine.Limit(time=0.1)).move
+
+
+# --------------------------
+# 3) Main
+# --------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="3-D rendered move overlay")
+    parser.add_argument(
+        "--vantage",
+        choices=["black", "white"],
+        default=None,
+        help="Force highlighting from one vantage (black/white).",
+    )
+    args = parser.parse_args()
+
+    forced_vantage = args.vantage
+
+    setup_virtual_cameras()
+
+    board, engine = setup_chess_engine()
+    if board is None:
+        return
+
+    cap_black = cv2.VideoCapture(0)
+    cap_white = cv2.VideoCapture(2)
+    if not cap_black.isOpened() or not cap_white.isOpened():
+        print("Could not open physical cameras!")
+        engine.quit()
+        return
+    for cap in (cap_black, cap_white):
+        cap.set(cv2.CAP_PROP_FPS, 30)
+        cap.set(cv2.CAP_PROP_FRAME_WIDTH, 640)
+        cap.set(cv2.CAP_PROP_FRAME_HEIGHT, 480)
+
+    print("Loading saved transforms…")
+    chess_vision.load_saved_transform()
+    black_transform = chess_vision.saved_transform.get(chess_vision.BLACK_SIDE_CAMERA)
+    white_transform = chess_vision.saved_transform.get(chess_vision.WHITE_SIDE_CAMERA)
+    if not black_transform or not white_transform:
+        print("Missing transforms!")
+        return
+
+    models = load_piece_models("stl")
+
+    with pyvirtualcam.Camera(640, 480, 30, fmt=PixelFormat.RGB, device='/dev/video4') as v_cam4, \
+         pyvirtualcam.Camera(640, 480, 30, fmt=PixelFormat.RGB, device='/dev/video5') as v_cam5, \
+         pyvirtualcam.Camera(640, 480, 30, fmt=PixelFormat.RGB, device='/dev/video6') as v_cam6, \
+         pyvirtualcam.Camera(640, 480, 30, fmt=PixelFormat.RGB, device='/dev/video7') as v_cam7, \
+         pyvirtualcam.Camera(640, 480, 30, fmt=PixelFormat.RGB, device='/dev/video8') as v_cam8:
+
+        print(f'LeRobot cams  : {v_cam4.device}, {v_cam5.device}')
+        print(f'OBS cams      : {v_cam6.device}, {v_cam7.device}')
+        print(f'Board diagram : {v_cam8.device}')
+        if forced_vantage:
+            print(f"MODE: Fixed vantage → {forced_vantage}")
+        else:
+            print("MODE: Normal swapping (white move ⇒ black cam).")
+
+        print("Keys: SPACE-next | r-reset | q-quit")
+
+        current_move = None
+        last_move_was_white = None
+        board_img_cache = generate_board_image(board, None)
+
+        while True:
+            ret_b, frame_black = cap_black.read()
+            ret_w, frame_white = cap_white.read()
+            if not (ret_b and ret_w):
+                print("Camera read failure.")
+                break
+
+            highlight_for_black = False
+            highlight_for_white = False
+            if current_move:
+                if forced_vantage is None:
+                    highlight_for_black = last_move_was_white
+                    highlight_for_white = not last_move_was_white
+                elif forced_vantage == "black":
+                    highlight_for_black = True
+                else:
+                    highlight_for_white = True
+
+            final_black_frame = render_board_state_with_move(
+                frame_black,
+                board,
+                models,
+                (black_transform['rvec'], black_transform['tvec']),
+                chess_vision.camera_matrix,
+                current_move if highlight_for_black else None,
+            )
+            final_white_frame = render_board_state_with_move(
+                frame_white,
+                board,
+                models,
+                (white_transform['rvec'], white_transform['tvec']),
+                chess_vision.camera_matrix,
+                current_move if highlight_for_white else None,
+            )
+
+
+            v_cam4.send(cv2.cvtColor(final_black_frame, cv2.COLOR_BGR2RGB))
+            v_cam6.send(cv2.cvtColor(final_black_frame, cv2.COLOR_BGR2RGB))
+            v_cam5.send(cv2.cvtColor(final_white_frame, cv2.COLOR_BGR2RGB))
+            v_cam7.send(cv2.cvtColor(final_white_frame, cv2.COLOR_BGR2RGB))
+            v_cam8.send(cv2.cvtColor(board_img_cache, cv2.COLOR_BGR2RGB))
+            v_cam8.sleep_until_next_frame()
+
+            cv2.imshow("Black cam", final_black_frame)
+            cv2.imshow("White cam", final_white_frame)
+            cv2.imshow("Board diagram", board_img_cache)
+
+            key = cv2.waitKey(1) & 0xFF
+            if key == ord('q'):
+                break
+            elif key == ord(' '):
+                if not board.is_game_over():
+                    last_move_was_white = board.turn
+                    next_move = get_next_move(board, engine)
+                    print(f"Engine move: {next_move.uci()}")
+                    board.push(next_move)
+                    current_move = next_move
+                    board_img_cache = generate_board_image(board, current_move)
+                else:
+                    print(f"Game over. Result: {board.result()}")
+            elif key == ord('r'):
+                board.reset()
+                current_move = None
+                last_move_was_white = None
+                board_img_cache = generate_board_image(board, None)
+                print("Board reset.")
+
+        cap_black.release()
+        cap_white.release()
+        cv2.destroyAllWindows()
+        engine.quit()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add new helper functions to create a 3‑D highlight overlay
- implement `render_board_state_with_move` for piece rendering and coloured squares
- add `dual_rendered_move.py` which mirrors `dual_highlight_move.py` but overlays the 3‑D render
- remove legacy flip mask logic from `dual_rendered_move.py`

## Testing
- `python -m py_compile dual_rendered_move.py board_3d_overlay.py`


------
https://chatgpt.com/codex/tasks/task_e_685bd5aeee108327b898cfeecfc47ecc